### PR TITLE
Fix NullPointerException when class model has some attributes not association

### DIFF
--- a/src/main/java/jp/ex_t/kazuaki/change_vision/ReflectTransaction.kt
+++ b/src/main/java/jp/ex_t/kazuaki/change_vision/ReflectTransaction.kt
@@ -216,14 +216,12 @@ class ReflectTransaction(private val projectChangedListener: ProjectChangedListe
 
     private fun createAssociationPresentation(sourceClassName: String, targetClassName: String, diagramName: String) {
         @Throws(ClassNotFoundException::class)
-        fun searchAssociation(sourceClass: IClass, targetClass: IClass): IAssociation? {
-            sourceClass.attributes.forEach { sourceClassAttribute ->
-                targetClass.attributes.forEach {
-                    if (sourceClassAttribute.association == it.association)
-                        return it.association
+        fun searchAssociation(sourceClass: IClass, targetClass: IClass): IAssociation {
+            return (sourceClass.attributes.filterNot { it.association == null }.find { sourceClassAttribute ->
+                targetClass.attributes.filterNot { it.association == null }.any { targetClassAttribute ->
+                    sourceClassAttribute.association == targetClassAttribute.association
                 }
-            }
-            throw ClassNotFoundException()
+            } ?: throw ClassNotFoundException()).association
         }
         val diagramEditorFactory = projectAccessor.diagramEditorFactory
         val classDiagramEditor = diagramEditorFactory.classDiagramEditor


### PR DESCRIPTION
2つのクラスが関連以外の属性を持っていた場合に関連を同期できない問題を修正しました

クラスから関連を取得するにはクラスが持つ属性の中から関連を取り出す必要がありますが、関連を持たない属性があるため全ての属性に対して関連を参照するとエラーが発生しました
そこで、関連を持つ属性のみにフィルタリングした上で関連を取得するように変更しました